### PR TITLE
Add simple Battleship UI with stats and log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Battleship
+
+This is a simple web-based Battleship game. Open `index.html` in a web browser to play.
+
+Use the **Start Game** button to enable clicks on the board and **Reset** to clear the board and stats. Shots, hits, misses, and recent actions are displayed in the stats section and log.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Battleship Game</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Battleship Game</h1>
+    <div id="controls">
+        <button id="startBtn">Start Game</button>
+        <button id="resetBtn">Reset</button>
+    </div>
+    <div id="stats">
+        <p>Shots Fired: <span id="shots">0</span></p>
+        <p>Hits: <span id="hits">0</span></p>
+        <p>Misses: <span id="misses">0</span></p>
+    </div>
+    <div id="board" class="grid"></div>
+    <h2>Action Log</h2>
+    <ul id="log"></ul>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,68 @@
+const board = document.getElementById('board');
+const startBtn = document.getElementById('startBtn');
+const resetBtn = document.getElementById('resetBtn');
+const shotsEl = document.getElementById('shots');
+const hitsEl = document.getElementById('hits');
+const missesEl = document.getElementById('misses');
+const logEl = document.getElementById('log');
+
+let shots = 0;
+let hits = 0;
+let misses = 0;
+let running = false;
+
+function initBoard() {
+    board.innerHTML = '';
+    for (let r = 0; r < 10; r++) {
+        for (let c = 0; c < 10; c++) {
+            const cell = document.createElement('div');
+            cell.classList.add('cell');
+            cell.dataset.row = r;
+            cell.dataset.col = c;
+            cell.addEventListener('click', cellClicked);
+            board.appendChild(cell);
+        }
+    }
+}
+
+function cellClicked(e) {
+    if (!running) return;
+    const cell = e.target;
+    if (cell.classList.contains('hit') || cell.classList.contains('miss')) return;
+    shots++;
+    shotsEl.textContent = shots;
+    // simple random hit/miss simulation
+    if (Math.random() < 0.3) {
+        cell.classList.add('hit');
+        hits++;
+        hitsEl.textContent = hits;
+        addLog(`Hit at (${cell.dataset.row}, ${cell.dataset.col})`);
+    } else {
+        cell.classList.add('miss');
+        misses++;
+        missesEl.textContent = misses;
+        addLog(`Miss at (${cell.dataset.row}, ${cell.dataset.col})`);
+    }
+}
+
+function addLog(text) {
+    const li = document.createElement('li');
+    li.textContent = text;
+    logEl.prepend(li);
+}
+
+startBtn.addEventListener('click', () => {
+    running = true;
+    addLog('Game started');
+});
+
+resetBtn.addEventListener('click', () => {
+    shots = hits = misses = 0;
+    shotsEl.textContent = hitsEl.textContent = missesEl.textContent = 0;
+    logEl.innerHTML = '';
+    initBoard();
+    running = false;
+    addLog('Game reset');
+});
+
+initBoard();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,43 @@
+body {
+    font-family: Arial, sans-serif;
+    text-align: center;
+    padding: 20px;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(10, 30px);
+    grid-template-rows: repeat(10, 30px);
+    gap: 2px;
+    margin: 20px auto;
+    width: fit-content;
+}
+
+.cell {
+    width: 30px;
+    height: 30px;
+    border: 1px solid #ccc;
+    cursor: pointer;
+}
+
+.cell.hit {
+    background-color: #4caf50;
+}
+
+.cell.miss {
+    background-color: #f44336;
+}
+
+#log {
+    list-style: none;
+    padding: 0;
+    max-height: 150px;
+    overflow-y: auto;
+    border: 1px solid #ddd;
+}
+
+#log li {
+    text-align: left;
+    padding: 4px;
+    border-bottom: 1px solid #eee;
+}


### PR DESCRIPTION
## Summary
- add basic web interface for the Battleship game
- show shots fired, hits and misses
- log user actions and add start/reset controls
- document how to play in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68654b988430832d90907aecb9ed01b0