### PR TITLE
Improve montage generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # Battleship
+
+This repository contains example code to create a video montage of gameplay improvements across different versions of the game.
+
+## Montage Script
+
+`montage.py` combines individual video clips into a single montage. It automatically looks for clips named `battleship_v1.mp4` through `battleship_v6.mp4` and `battleship_final.mp4` in the `videos/` directory.
+
+### Requirements
+
+- Python 3
+- [`moviepy`](https://zulko.github.io/moviepy/) library
+
+Install the dependency with:
+
+```bash
+pip install moviepy
+```
+
+### Usage
+
+Place your recorded clips in a folder called `videos/` using the naming
+convention above and run:
+
+```bash
+python3 montage.py
+```
+
+The resulting `montage.mp4` will contain a simple crossfaded sequence of your gameplay videos with captions showing the version number.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ python3 montage.py
 ```
 
 The resulting `montage.mp4` will contain a simple crossfaded sequence of your gameplay videos with captions showing the version number.
+
+## Browser Montage
+
+Alternatively, open `montage.html` in any modern browser. It attempts to play the
+same `battleship_v1.mp4` … `battleship_final.mp4` clips from the `videos/`
+directory. Clips that are missing are skipped automatically. Each segment is
+displayed with a short caption and a fade transition between videos.

--- a/montage.html
+++ b/montage.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Battleship Montage</title>
+<style>
+  body {
+    margin: 0;
+    background: #000;
+    color: #fff;
+    font-family: Arial, sans-serif;
+    text-align: center;
+  }
+  #container {
+    position: relative;
+    width: 100%;
+    height: 100vh;
+    overflow: hidden;
+  }
+  video {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    opacity: 0;
+    transition: opacity 0.5s linear;
+  }
+  .visible {
+    opacity: 1;
+  }
+  .caption {
+    position: absolute;
+    bottom: 10px;
+    left: 0;
+    right: 0;
+    text-shadow: 0 0 5px #000;
+    font-size: 1.5em;
+  }
+</style>
+</head>
+<body>
+<h1>Battleship Montage</h1>
+<div id="container">
+  <video id="videoA" muted></video>
+  <video id="videoB" muted></video>
+  <div id="caption" class="caption"></div>
+</div>
+<script>
+const SEGMENTS = [
+  {file: 'videos/battleship_v1.mp4', caption: 'Version 1'},
+  {file: 'videos/battleship_v2.mp4', caption: 'Version 2'},
+  {file: 'videos/battleship_v3.mp4', caption: 'Version 3'},
+  {file: 'videos/battleship_v4.mp4', caption: 'Version 4'},
+  {file: 'videos/battleship_v5.mp4', caption: 'Version 5'},
+  {file: 'videos/battleship_v6.mp4', caption: 'Version 6'},
+  {file: 'videos/battleship_final.mp4', caption: 'Final Version'}
+];
+let current = 0;
+let active = document.getElementById('videoA');
+let next = document.getElementById('videoB');
+const caption = document.getElementById('caption');
+
+function playSegment() {
+  if (current >= SEGMENTS.length) {
+    caption.textContent = '';
+    return;
+  }
+  const segment = SEGMENTS[current];
+  next.src = segment.file;
+  caption.textContent = segment.caption;
+  next.load();
+  next.oncanplay = () => {
+    next.classList.add('visible');
+    next.play();
+    active.classList.remove('visible');
+    setTimeout(() => {
+      active.pause();
+      const tmp = active;
+      active = next;
+      next = tmp;
+      current += 1;
+      active.onended = playSegment;
+    }, 500);
+  };
+  next.onerror = () => {
+    current += 1;
+    playSegment();
+  };
+}
+
+window.onload = () => {
+  active.src = SEGMENTS[current].file;
+  caption.textContent = SEGMENTS[current].caption;
+  active.classList.add('visible');
+  active.onended = playSegment;
+  active.onerror = playSegment;
+  active.load();
+  active.play();
+};
+</script>
+</body>
+</html>

--- a/montage.py
+++ b/montage.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+import os
+from moviepy import VideoFileClip, TextClip, CompositeVideoClip, concatenate_videoclips
+
+
+def create_montage(video_segments, output_path: str = "montage.mp4", fade_duration: float = 0.5):
+    """Create a montage from a list of video segments.
+
+    Parameters
+    ----------
+    video_segments : list of dict
+        Each dictionary must contain:
+        - 'file': path to the video clip
+        - 'caption': text to overlay on that clip describing improvements
+    output_path : str
+        Path where the montage video will be saved.
+    fade_duration : float
+        Duration of the fade transition between clips in seconds.
+    """
+    clips = []
+    for segment in video_segments:
+        path = segment["file"]
+        caption = segment.get("caption", "")
+        clip = VideoFileClip(path)
+        if caption:
+            # Create a semi-transparent text overlay
+            txt_clip = TextClip(caption, fontsize=24, color="white")
+            txt_clip = txt_clip.set_position(("center", "bottom")).set_duration(clip.duration)
+            clip = CompositeVideoClip([clip, txt_clip])
+        clips.append(clip)
+
+    # Add crossfade transitions
+    final = clips[0]
+    for clip in clips[1:]:
+        final = concatenate_videoclips([final, clip], method="compose", padding=-fade_duration)
+
+    final.write_videofile(output_path, codec="libx264")
+
+
+def load_segments(video_dir: str = "videos") -> list[dict[str, str]]:
+    """Return segments for versions 1..6 and final if the files exist."""
+    segments = []
+    for i in range(1, 7):
+        path = os.path.join(video_dir, f"battleship_v{i}.mp4")
+        if os.path.exists(path):
+            segments.append({"file": path, "caption": f"Version {i}"})
+    final_path = os.path.join(video_dir, "battleship_final.mp4")
+    if os.path.exists(final_path):
+        segments.append({"file": final_path, "caption": "Final Version"})
+    return segments
+
+
+if __name__ == "__main__":
+    segments = load_segments()
+    if not segments:
+        raise SystemExit("No video segments found in the 'videos/' directory.")
+    create_montage(segments)


### PR DESCRIPTION
## Summary
- refine montage script to auto-load versions v1-v6 and final
- simplify imports for the new moviepy package layout
- document automatic segment lookup in README

## Testing
- `python3 -m py_compile montage.py`
- `python3 montage.py` (fails with message when `videos/` is empty)


------
https://chatgpt.com/codex/tasks/task_e_6866b63a1560832d888c54c9f64f9dac